### PR TITLE
Petpal noahg/extension/tac reading

### DIFF
--- a/petpal/cli/cli_tac_interpolation.py
+++ b/petpal/cli/cli_tac_interpolation.py
@@ -38,7 +38,7 @@ import os
 import argparse
 import numpy as np
 from ..kinetic_modeling import tac_interpolation as tac_intp
-from utils.time_activity_curve import safe_load_tac
+from ..utils.time_activity_curve import safe_load_tac
 
 
 def _safe_write_tac(tac_times: np.ndarray, tac_values: np.ndarray, filename: str) -> None:

--- a/petpal/cli/cli_tac_interpolation.py
+++ b/petpal/cli/cli_tac_interpolation.py
@@ -38,9 +38,7 @@ import os
 import argparse
 import numpy as np
 from ..kinetic_modeling import tac_interpolation as tac_intp
-from ..utils.image_io import safe_load_tac
-
-
+from utils.time_activity_curve import safe_load_tac
 
 
 def _safe_write_tac(tac_times: np.ndarray, tac_values: np.ndarray, filename: str) -> None:

--- a/petpal/input_function/blood_input.py
+++ b/petpal/input_function/blood_input.py
@@ -4,7 +4,7 @@ from pandas import read_csv
 from scipy.interpolate import interp1d as sp_interp
 from scipy.optimize import curve_fit as sp_fit
 
-import utils.time_activity_curve
+from ..utils import time_activity_curve
 from ..utils import image_io
 
 
@@ -179,7 +179,7 @@ def resample_blood_data_on_scanner_times(blood_tac_path: str,
     assert rescale_constant > 0.0, "Rescale constant must be greater than zero."
     image_meta_data = image_io.load_metadata_for_nifti_with_same_filename(image_path=reference_4dpet_img_path)
     frame_times = np.asarray(image_meta_data['FrameReferenceTime']) / 60.0
-    blood_times, blood_activity = utils.time_activity_curve.safe_load_tac(filename=blood_tac_path)
+    blood_times, blood_activity = time_activity_curve.safe_load_tac(filename=blood_tac_path)
     blood_intp = BloodInputFunction(time=blood_times, activity=blood_activity, thresh_in_mins=lin_fit_thresh_in_mins)
     resampled_blood = blood_intp.calc_blood_input_function(t=frame_times)
     resampled_blood *= rescale_constant

--- a/petpal/input_function/blood_input.py
+++ b/petpal/input_function/blood_input.py
@@ -3,6 +3,8 @@ import numpy as np
 from pandas import read_csv
 from scipy.interpolate import interp1d as sp_interp
 from scipy.optimize import curve_fit as sp_fit
+
+import utils.time_activity_curve
 from ..utils import image_io
 
 
@@ -177,7 +179,7 @@ def resample_blood_data_on_scanner_times(blood_tac_path: str,
     assert rescale_constant > 0.0, "Rescale constant must be greater than zero."
     image_meta_data = image_io.load_metadata_for_nifti_with_same_filename(image_path=reference_4dpet_img_path)
     frame_times = np.asarray(image_meta_data['FrameReferenceTime']) / 60.0
-    blood_times, blood_activity = image_io.safe_load_tac(filename=blood_tac_path)
+    blood_times, blood_activity = utils.time_activity_curve.safe_load_tac(filename=blood_tac_path)
     blood_intp = BloodInputFunction(time=blood_times, activity=blood_activity, thresh_in_mins=lin_fit_thresh_in_mins)
     resampled_blood = blood_intp.calc_blood_input_function(t=frame_times)
     resampled_blood *= rescale_constant

--- a/petpal/kinetic_modeling/graphical_analysis.py
+++ b/petpal/kinetic_modeling/graphical_analysis.py
@@ -23,7 +23,7 @@ import json
 import numba
 import numpy as np
 from ..utils.time_activity_curve import MultiTACAnalysisMixin
-from ..utils.image_io import safe_load_tac
+from utils.time_activity_curve import safe_load_tac
 
 
 @numba.njit()

--- a/petpal/kinetic_modeling/graphical_analysis.py
+++ b/petpal/kinetic_modeling/graphical_analysis.py
@@ -23,7 +23,7 @@ import json
 import numba
 import numpy as np
 from ..utils.time_activity_curve import MultiTACAnalysisMixin
-from utils.time_activity_curve import safe_load_tac
+from ..utils.time_activity_curve import safe_load_tac
 
 
 @numba.njit()

--- a/petpal/kinetic_modeling/parametric_images.py
+++ b/petpal/kinetic_modeling/parametric_images.py
@@ -402,8 +402,8 @@ class ReferenceTissueParametricImage:
         """
         pet_np = self.pet_image.get_fdata()
         mask_np = self.mask_image.get_fdata()
-        tac_times_in_minutes = self.reference_tac.tac_times_in_minutes
-        ref_tac_vals = self.reference_tac.tac_vals
+        tac_times_in_minutes = self.reference_tac.times
+        ref_tac_vals = self.reference_tac.activity
         method = self.method
         rtm_method = get_rtm_method(method)
         analysis_kwargs = get_rtm_kwargs(method=rtm_method,

--- a/petpal/kinetic_modeling/parametric_images.py
+++ b/petpal/kinetic_modeling/parametric_images.py
@@ -22,7 +22,7 @@ from petpal.kinetic_modeling.reference_tissue_models import (fit_mrtm2_2003_to_t
 from petpal.kinetic_modeling.fit_tac_with_rtms import (get_rtm_kwargs,
                                                        get_rtm_method,
                                                        get_rtm_output_size)
-from petpal.utils.time_activity_curve import TimeActivityCurveFromFile
+from petpal.utils.time_activity_curve import TimeActivityCurve
 from petpal.utils.image_io import safe_load_4dpet_nifti
 from . import graphical_analysis
 from ..input_function.blood_input import read_plasma_glucose_concentration
@@ -309,7 +309,7 @@ class ReferenceTissueParametricImage:
             output_filename_prefix (str): Prefix for output files saved after analysis.
             method (str): RTM method to run. Default 'mrtm2'.
         """
-        self.reference_tac = TimeActivityCurveFromFile(tac_path=reference_tac_path)
+        self.reference_tac = TimeActivityCurve.from_tsv(filename=reference_tac_path)
         self.pet_image = safe_load_4dpet_nifti(pet_image_path)
         self.mask_image = safe_load_4dpet_nifti(mask_image_path)
 

--- a/petpal/kinetic_modeling/parametric_images.py
+++ b/petpal/kinetic_modeling/parametric_images.py
@@ -26,7 +26,8 @@ from petpal.utils.time_activity_curve import TimeActivityCurveFromFile
 from petpal.utils.image_io import safe_load_4dpet_nifti
 from . import graphical_analysis
 from ..input_function.blood_input import read_plasma_glucose_concentration
-from ..utils.image_io import safe_load_tac, safe_copy_meta, validate_two_images_same_dimensions
+from ..utils.image_io import safe_copy_meta, validate_two_images_same_dimensions
+from utils.time_activity_curve import safe_load_tac
 
 
 @numba.njit()

--- a/petpal/kinetic_modeling/parametric_images.py
+++ b/petpal/kinetic_modeling/parametric_images.py
@@ -27,7 +27,7 @@ from petpal.utils.image_io import safe_load_4dpet_nifti
 from . import graphical_analysis
 from ..input_function.blood_input import read_plasma_glucose_concentration
 from ..utils.image_io import safe_copy_meta, validate_two_images_same_dimensions
-from utils.time_activity_curve import safe_load_tac
+from ..utils.time_activity_curve import safe_load_tac
 
 
 @numba.njit()

--- a/petpal/kinetic_modeling/rtm_analysis.py
+++ b/petpal/kinetic_modeling/rtm_analysis.py
@@ -309,9 +309,9 @@ class RTMAnalysis:
         else:
             bp_val = calc_bp_from_mrtm2_2003_fit(fit_ans)
             k2_val = None
-        props_dict["k2Prime"] = k2_val.round(5)
-        props_dict["BP"] = bp_val.round(5)
-        props_dict["RawFits"] = list(fit_ans.round(5))
+        props_dict["k2Prime"] = k2_val
+        props_dict["BP"] = bp_val
+        props_dict["RawFits"] = list(fit_ans)
 
         if write_simulated:
             props_dict["SimulatedFits"] = list(y_fit.round(7))

--- a/petpal/kinetic_modeling/rtm_analysis.py
+++ b/petpal/kinetic_modeling/rtm_analysis.py
@@ -12,7 +12,7 @@ from petpal.kinetic_modeling.reference_tissue_models import (calc_k2prime_from_m
                                                              calc_bp_from_mrtm2_2003_fit,
                                                              calc_bp_from_mrtm_original_fit,
                                                              calc_bp_from_mrtm_2003_fit)
-from utils.time_activity_curve import safe_load_tac
+from ..utils.time_activity_curve import safe_load_tac
 from ..utils.time_activity_curve import MultiTACAnalysisMixin
 
 

--- a/petpal/kinetic_modeling/rtm_analysis.py
+++ b/petpal/kinetic_modeling/rtm_analysis.py
@@ -12,7 +12,7 @@ from petpal.kinetic_modeling.reference_tissue_models import (calc_k2prime_from_m
                                                              calc_bp_from_mrtm2_2003_fit,
                                                              calc_bp_from_mrtm_original_fit,
                                                              calc_bp_from_mrtm_2003_fit)
-from petpal.utils.image_io import safe_load_tac
+from utils.time_activity_curve import safe_load_tac
 from ..utils.time_activity_curve import MultiTACAnalysisMixin
 
 

--- a/petpal/kinetic_modeling/tac_fitting.py
+++ b/petpal/kinetic_modeling/tac_fitting.py
@@ -29,8 +29,7 @@ from scipy.optimize import curve_fit as sp_cv_fit
 from . import tcms_as_convolutions as pet_tcms
 from ..input_function import blood_input as pet_bld
 from ..utils.time_activity_curve import safe_load_tac
-from ..utils.time_activity_curve import TimeActivityCurveFromFile, MultiTACAnalysisMixin
-import glob
+from ..utils.time_activity_curve import MultiTACAnalysisMixin
 
 def _get_fitting_params_for_tcm_func(f: Callable) -> list:
     r"""

--- a/petpal/kinetic_modeling/tac_fitting.py
+++ b/petpal/kinetic_modeling/tac_fitting.py
@@ -28,7 +28,7 @@ import numpy as np
 from scipy.optimize import curve_fit as sp_cv_fit
 from . import tcms_as_convolutions as pet_tcms
 from ..input_function import blood_input as pet_bld
-from ..utils.image_io import safe_load_tac
+from utils.time_activity_curve import safe_load_tac
 from ..utils.time_activity_curve import TimeActivityCurveFromFile, MultiTACAnalysisMixin
 import glob
 

--- a/petpal/kinetic_modeling/tac_fitting.py
+++ b/petpal/kinetic_modeling/tac_fitting.py
@@ -28,7 +28,7 @@ import numpy as np
 from scipy.optimize import curve_fit as sp_cv_fit
 from . import tcms_as_convolutions as pet_tcms
 from ..input_function import blood_input as pet_bld
-from utils.time_activity_curve import safe_load_tac
+from ..utils.time_activity_curve import safe_load_tac
 from ..utils.time_activity_curve import TimeActivityCurveFromFile, MultiTACAnalysisMixin
 import glob
 

--- a/petpal/utils/image_io.py
+++ b/petpal/utils/image_io.py
@@ -126,33 +126,6 @@ def flatten_metadata(metadata: dict) -> dict:
     return metadata_for_tsv
 
 
-def safe_load_tac(filename: str, **kwargs) -> np.ndarray:
-    """
-    Loads time-activity curves (TAC) from a file.
-    Tries to read a TAC from specified file and raises an exception if unable to do so. We assume that the file has two
-    columns, the first corresponding to time and second corresponding to activity.
-    Args:
-        filename (str): The name of the file to be loaded.
-    Returns:
-        np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the times, and the second
-        corresponds to the activity.
-    Raises:
-        Exception: An error occurred loading the TAC.
-    """
-    try:
-        tac_data = np.asarray(np.loadtxt(filename, **kwargs).T, dtype=float, order='C')
-    except ValueError:
-        tac_data = np.asarray(np.loadtxt(filename, skiprows=1, **kwargs).T, dtype=float, order='C')
-    except Exception as e:
-        print(f"Couldn't read file {filename}. Error: {e}")
-        raise e
-
-    if np.max(tac_data[0]) >= 300:
-        tac_data[0] /= 60.0
-
-    return tac_data
-
-
 def safe_copy_meta(input_image_path: str,
                    out_image_path: str):
     """

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -18,6 +18,8 @@ class TimeActivityCurve:
     Attributes:
         times (np.ndarray): Frame times for the TAC stored in an array.
         activity (np.ndarray): Activity values at each frame time stored in an array.
+        uncertainty (np.ndarray): Uncertainty in the measurement of activity values stored in an
+            array.
 
 
     Example:
@@ -307,7 +309,7 @@ class MultiTACAnalysisMixin:
         Returns:
             list: List of TAC values.
         """
-        tacs_vals = [tac.tac_vals for tac in tacs_objects_list]
+        tacs_vals = [tac.activity for tac in tacs_objects_list]
         return tacs_vals
     
     def get_tacs_vals_from_dir(self, tacs_dir: str):

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -30,6 +30,10 @@ class TimeActivityCurve:
             f"TAC fields must have the same shapes.\ntimes:{self.times.shape}"
             "activity:{self.activity.shape} uncertainty:{self.uncertainty.shape}")
 
+    @classmethod
+    def from_tsv(cls, filename: str):
+        return cls(*safe_load_tac(filename=filename, with_uncertainty=True))
+
     @property
     def tac(self) -> np.ndarray:
         return np.ascontiguousarray([self.times, self.activity])
@@ -47,11 +51,12 @@ def safe_load_tac(filename: str,
     Tries to read a TAC from specified file and raises an exception if unable to do so. We assume that the file has two
     columns, the first corresponding to time and second corresponding to activity.
     Args:
-        with_uncertainty (bool): 
+        with_uncertainty (bool):
         filename (str): The name of the file to be loaded.
+        **kwargs (dict): keyword arguments to pass to :func:`np.loadtxt`.
     Returns:
         np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the times, and the second
-        corresponds to the activity.
+            corresponds to the activity. If with_uncertainty is True, the third index corresponds to the uncertainty.
     Raises:
         Exception: An error occurred loading the TAC.
     """

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -58,7 +58,7 @@ class TimeActivityCurve:
         return np.ascontiguousarray([self.times, self.activity, self.uncertainty])
 
     def to_tsv(self, filename: str, col_names: list[str]=None):
-        if self.uncertainty:
+        if self.uncertainty is not None:
             safe_write_tac(filename=filename,tac_data=self.tac_werr,col_names=col_names)
         else:
             safe_write_tac(filename=filename,tac_data=self.tac,col_names=col_names)

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -77,6 +77,44 @@ def safe_load_tac(filename: str,
         return tac_data[:2]
 
 
+def safe_write_tac(filename: str,
+                   tac_data: np.ndarray,
+                   col_names: list[str]=None):
+    """
+    Writes the data in a time-activity curve (TAC) to a file. Assumes the TAC data consists of a
+    contiguous numpy array with two or three columns: time, activity, and (optionally) uncertainty.
+
+    Args:
+        filename (str): Path to the file the data will be saved as.
+        tac_data (np.ndarray): Numpy array containing the data for the TAC. Assumes the TAC data
+            consists of a contiguous numpy array with two or three columns: time, activity, and 
+            (optionally) uncertainty.
+        col_names (list[str]): List of column names assigned to the time, activity, and uncertainty
+            columns in the TAC data, respectively. Must match number of columns in `tac_data`.
+    
+    Raises:
+        ValueError: If the number of columns in tac_data is not two or three, or the number of
+            columns in tac_data does not match the number of columns in col_names.
+    """
+    num_cols = len(tac_data)
+    if num_cols not in (2, 3):
+        raise ValueError(f"Expected two or three columns in tac_data. Got {num_cols}.")
+
+    if col_names is None:
+        if num_cols==2:
+            col_names = ['FrameReferenceTime', 'MeanActivityConcentration']
+        elif num_cols==3:
+            col_names = ['FrameReferenceTime', 'MeanActivityConcentration','Uncertainty']
+    
+    if num_cols!=len(col_names):
+        raise ValueError("Expected the same number of columns in tac_data and col_names. Got "
+                         f"{num_cols} in tac_data and {len(col_names)} in col_names.")
+
+    col_names_with_sep = [col+'\t' for col in col_names]
+    file_header = ''.join(col_names_with_sep)
+    np.savetxt(fname=filename, X=tac_data, header=file_header)
+
+
 class MultiTACAnalysisMixin:
     """
     A mixin class providing utilities for handling multiple analysis of Time Activity Curves (TACs)

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -240,18 +240,18 @@ class MultiTACAnalysisMixin:
             tacs_files_list (list[str]): List of TAC file paths.
 
         Returns:
-            list[TimeActivityCurveFromFile]: List of TAC objects.
+            list[TimeActivityCurve]: List of TAC objects.
         """
-        tacs_list = [TimeActivityCurveFromFile(tac_path=tac_file) for tac_file in tacs_files_list]
+        tacs_list = [TimeActivityCurve.from_tsv(filename=tac_file) for tac_file in tacs_files_list]
         return tacs_list
     
     @staticmethod
-    def get_tacs_vals_from_objs_list(tacs_objects_list: list[TimeActivityCurveFromFile]):
+    def get_tacs_vals_from_objs_list(tacs_objects_list: list[TimeActivityCurve]):
         """
         Extracts TAC values from a list of TAC objects.
 
         Args:
-            tacs_objects_list (list[TimeActivityCurveFromFile]): List of TAC objects.
+            tacs_objects_list (list[TimeActivityCurve]): List of TAC objects.
 
         Returns:
             list: List of TAC values.

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -7,7 +7,7 @@ TODO:
     * Refactor safe_load_tac to this module as a public method
 
 """
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import numpy as np
 import os, glob, pathlib
 
@@ -16,10 +16,27 @@ class TimeActivityCurve:
     """Class to store time activity curve (TAC) data.
     
     Attributes:
-        tac_times_in_minutes (np.ndarray): Frame times for the TAC stored in an array.
-        tac_vals (np.ndarray): Activity values at each frame time stored in an array."""
-    tac_times_in_minutes: np.ndarray
-    tac_vals: np.ndarray
+        times (np.ndarray): Frame times for the TAC stored in an array.
+        activity (np.ndarray): Activity values at each frame time stored in an array.
+    """
+    times: np.ndarray
+    activity: np.ndarray
+    uncertainty: np.ndarray = field(default_factory=lambda: np.array([]))
+
+    def __post_init__(self):
+        if self.uncertainty.size == 0:
+            self.uncertainty = np.zeros_like(self.times)
+        assert np.shape(self.uncertainty) == np.shape(self.times) == np.shape(self.activity), (
+            f"TAC fields must have the same shapes.\ntimes:{self.times.shape}"
+            "activity:{self.activity.shape} uncertainty:{self.uncertainty.shape}")
+
+    @property
+    def tac(self) -> np.ndarray:
+        return np.ascontiguousarray([self.times, self.activity])
+
+    @property
+    def tac_werr(self) -> np.ndarray:
+        return np.ascontiguousarray([self.times, self.activity, self.uncertainty])
 
 
 class TimeActivityCurveFromFile:

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -107,7 +107,7 @@ def safe_write_tac(filename: str,
 
             my_tac = safe_load_tac(filename='/path/to/tac.tsv')
             my_tac_modified = np.zeros_like(my_tac)
-            my_tac_modified[0] = my_tac[0] / 60 # convert time units to seconds
+            my_tac_modified[0] = my_tac[0] / 60 # convert time units to hours
             my_tac_modified[1] = my_tac[1] / 37000 # convert activity units to mCi
             my_tac_modified[2] = my_tac[2] / 37000 # convert uncertainties like activity
             safe_write_tac(filename='/path/to/new_tac.tsv',

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -215,7 +215,7 @@ def safe_write_tac(filename: str,
                          f"{num_cols} in tac_data and {len(col_names)} in col_names.")
 
     file_header = "\t".join(col_names)
-    np.savetxt(fname=filename, X=tac_data.T, header=file_header)
+    np.savetxt(fname=filename, X=tac_data.T, header=file_header, comments='')
 
 
 class MultiTACAnalysisMixin:

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -50,6 +50,15 @@ class TimeActivityCurve:
 
     @classmethod
     def from_tsv(cls, filename: str):
+        """
+        Load an instance of TimeActivityCurve object from a TSV TAC file.
+
+        Args:
+            filename (str): Path to the TSV TAC file.
+        
+        Returns:
+            (TimeActivityCurve): A TimeActivityCurve object loaded from a TSV TAC file.
+        """
         return cls(*safe_load_tac(filename=filename, with_uncertainty=True))
 
     @property

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -39,12 +39,15 @@ class TimeActivityCurve:
         return np.ascontiguousarray([self.times, self.activity, self.uncertainty])
 
 
-def safe_load_tac(filename: str, **kwargs) -> np.ndarray:
+def safe_load_tac(filename: str,
+                  with_uncertainty: bool = False,
+                  **kwargs) -> np.ndarray:
     """
     Loads time-activity curves (TAC) from a file.
     Tries to read a TAC from specified file and raises an exception if unable to do so. We assume that the file has two
     columns, the first corresponding to time and second corresponding to activity.
     Args:
+        with_uncertainty (bool): 
         filename (str): The name of the file to be loaded.
     Returns:
         np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the times, and the second
@@ -63,7 +66,10 @@ def safe_load_tac(filename: str, **kwargs) -> np.ndarray:
     if np.max(tac_data[0]) >= 300:
         tac_data[0] /= 60.0
 
-    return tac_data
+    if with_uncertainty:
+        return tac_data[:3]
+    else:
+        return tac_data[:2]
 
 
 class TimeActivityCurveFromFile:

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -95,6 +95,24 @@ def safe_write_tac(filename: str,
     Raises:
         ValueError: If the number of columns in tac_data is not two or three, or the number of
             columns in tac_data does not match the number of columns in col_names.
+
+
+
+    Example:
+
+        .. code-block:: python
+
+            import numpy as np
+            from petpal.utils.time_activity_curve import safe_load_tac, safe_write_tac
+
+            my_tac = safe_load_tac(filename='/path/to/tac.tsv')
+            my_tac_modified = np.zeros_like(my_tac)
+            my_tac_modified[0] = my_tac[0] / 60 # convert time units to seconds
+            my_tac_modified[1] = my_tac[1] / 37000 # convert activity units to mCi
+            my_tac_modified[2] = my_tac[2] / 37000 # convert uncertainties like activity
+            safe_write_tac(filename='/path/to/new_tac.tsv',
+                           tac_data=my_tac_modified)
+
     """
     num_cols = len(tac_data)
     if num_cols not in (2, 3):

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -77,60 +77,6 @@ def safe_load_tac(filename: str,
         return tac_data[:2]
 
 
-class TimeActivityCurveFromFile:
-    """
-    Class to handle data related to time activity curves (TACs).
-
-    Attributes:
-        tac_path (str): Path to the original time activity curve file.
-        tac_times_in_minutes (np.ndarray): Frame times for the TAC stored in an array.
-        tac_vals (np.ndarray): Activity values at each frame time stored in an array.
-    """
-    def __init__(self,
-                 tac_path: str):
-        """
-        Initialize TimeActivityCurve class
-
-        Args:
-            tac_path (str): Path to the TAC that will be analyzed.
-        """
-        self.tac_path = tac_path
-        self.tac_times_in_minutes, self.tac_vals = self.get_tac_data()
-
-    def get_tac_data(self):
-        """
-        Retrieves data from the TAC file. Uses :meth:`petpal.utils.image_io.safe_load_tac`.
-
-        See also:
-            * :meth:`petpal.utils.image_io.safe_load_tac`
-
-        """
-        return safe_load_tac(self.tac_path)
-
-    def get_frame_durations(self) -> np.ndarray:
-        """
-        Get array containing the duration of each frame in minutes.
-
-        For a set of N frames, the first N-1 frame durations are estimated as the difference
-        between each frame time and the next frame time. Frame N is then inferred as being the same
-        duration as frame N-1.
-
-        The frame durations in the originating metadata is preferable to computing it here. 
-        However, if the frame durations are not present in the metadata this function is useful
-        to recover them.
-
-        Returns:
-            tac_durations_in_minutes (np.ndarray): The estimated duration of each frame in minutes.
-        """
-        tac_times_in_minutes = self.tac_times_in_minutes
-        tac_durations_in_minutes = np.zeros((len(tac_times_in_minutes)))
-
-        tac_durations_in_minutes[:-1] = tac_times_in_minutes[1:]-tac_times_in_minutes[:-1]
-        tac_durations_in_minutes[-1] = tac_durations_in_minutes[-2]
-
-        return tac_durations_in_minutes
-
-
 class MultiTACAnalysisMixin:
     """
     A mixin class providing utilities for handling multiple analysis of Time Activity Curves (TACs)

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -72,6 +72,15 @@ class TimeActivityCurve:
 
 
     def to_tsv(self, filename: str, col_names: list[str]=None):
+        """
+        Writes the TAC object to file. If uncertainty includes any zero values, writes only time
+        and activity, otherwise writes time, activity, and uncertainty.
+
+        Args:
+            filename (str): Path to the file that will be written to.
+            col_names (list[str]): Custom names for time, activity, and uncertainty columns
+                respectively. See :meth:`safe_write_tac`. Default None.
+        """
         if np.any(self.uncertainty==0):
             safe_write_tac(filename=filename,tac_data=self.tac,col_names=col_names)
         else:

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -166,8 +166,7 @@ def safe_write_tac(filename: str,
         raise ValueError("Expected the same number of columns in tac_data and col_names. Got "
                          f"{num_cols} in tac_data and {len(col_names)} in col_names.")
 
-    col_names_with_sep = [col+'\t' for col in col_names]
-    file_header = ''.join(col_names_with_sep)
+    file_header = "\t".join(col_names)
     np.savetxt(fname=filename, X=tac_data.T, header=file_header)
 
 

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -130,7 +130,7 @@ def safe_write_tac(filename: str,
 
     col_names_with_sep = [col+'\t' for col in col_names]
     file_header = ''.join(col_names_with_sep)
-    np.savetxt(fname=filename, X=tac_data, header=file_header)
+    np.savetxt(fname=filename, X=tac_data.T, header=file_header)
 
 
 class MultiTACAnalysisMixin:

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -42,7 +42,8 @@ class TimeActivityCurve:
 
     def __post_init__(self):
         if self.uncertainty.size == 0:
-            self.uncertainty = np.zeros_like(self.times)
+            self.uncertainty = np.empty_like(self.times)
+            self.uncertainty[:] = np.nan
         assert np.shape(self.uncertainty) == np.shape(self.times) == np.shape(self.activity), (
             f"TAC fields must have the same shapes.\ntimes:{self.times.shape}"
             "activity:{self.activity.shape} uncertainty:{self.uncertainty.shape}")
@@ -73,18 +74,14 @@ class TimeActivityCurve:
 
     def to_tsv(self, filename: str, col_names: list[str]=None):
         """
-        Writes the TAC object to file. If uncertainty includes any zero values, writes only time
-        and activity, otherwise writes time, activity, and uncertainty.
+        Writes the TAC object to file, including measurement times, activity, and uncertainty.
 
         Args:
             filename (str): Path to the file that will be written to.
             col_names (list[str]): Custom names for time, activity, and uncertainty columns
                 respectively. See :meth:`safe_write_tac`. Default None.
         """
-        if np.any(self.uncertainty==0):
-            safe_write_tac(filename=filename,tac_data=self.tac,col_names=col_names)
-        else:
-            safe_write_tac(filename=filename,tac_data=self.tac_werr,col_names=col_names)
+        safe_write_tac(filename=filename,tac_data=self.tac_werr,col_names=col_names)
 
 
 def safe_load_tac(filename: str,

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -57,6 +57,18 @@ class TimeActivityCurve:
     def tac_werr(self) -> np.ndarray:
         return np.ascontiguousarray([self.times, self.activity, self.uncertainty])
 
+    @property
+    def times_in_mins(self) -> np.ndarray[float]:
+        """
+        Returns the TAC measured times in minutes. Validates values by checking if the final
+        frame value is greater than 200: if so, then assumes values are in seconds and divides by
+        60.
+        """
+        if self.times[-1] >= 200.0:
+            return self.times / 60.0
+        return self.times
+
+
     def to_tsv(self, filename: str, col_names: list[str]=None):
         if self.uncertainty is not None:
             safe_write_tac(filename=filename,tac_data=self.tac_werr,col_names=col_names)

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -42,6 +42,13 @@ class TimeActivityCurve:
     def tac_werr(self) -> np.ndarray:
         return np.ascontiguousarray([self.times, self.activity, self.uncertainty])
 
+    def to_tsv(self, filename: str, col_names: list[str]=None):
+        if self.uncertainty:
+            safe_write_tac(filename=filename,tac_data=self.tac_werr,col_names=col_names)
+        else:
+            safe_write_tac(filename=filename,tac_data=self.tac,col_names=col_names)
+
+
 
 def safe_load_tac(filename: str,
                   with_uncertainty: bool = False,

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -18,6 +18,21 @@ class TimeActivityCurve:
     Attributes:
         times (np.ndarray): Frame times for the TAC stored in an array.
         activity (np.ndarray): Activity values at each frame time stored in an array.
+
+
+    Example:
+
+        .. code-block:: python
+
+            from petpal.utils.time_activity_curve import TimeActivityCurve
+
+            my_tac = TimeActivityCurve.from_tsv('/path/to/tac.tsv')
+            print(f"Frame times: {my_tac.times}")
+            print(f"Activity: {my_tac.activity}")
+            print(f"Uncertainty: {my_tac.uncertainty}")
+
+            my_tac.times = my_tac.times / 60  # convert time units to hours
+            my_tac.to_tsv(filename='/path/to/new_tac.tsv')  # save as new file
     """
     times: np.ndarray
     activity: np.ndarray
@@ -66,6 +81,22 @@ def safe_load_tac(filename: str,
             corresponds to the activity. If with_uncertainty is True, the third index corresponds to the uncertainty.
     Raises:
         Exception: An error occurred loading the TAC.
+
+        
+    Example:
+
+        .. code-block:: python
+
+            import numpy as np
+            from petpal.utils.time_activity_curve import safe_load_tac, safe_write_tac
+
+            my_tac = safe_load_tac(filename='/path/to/tac.tsv')
+            my_tac_modified = np.zeros_like(my_tac)
+            my_tac_modified[0] = my_tac[0] / 60 # convert time units to hours
+            my_tac_modified[1] = my_tac[1] / 37000 # convert activity units to mCi
+            my_tac_modified[2] = my_tac[2] / 37000 # convert uncertainties like activity
+            safe_write_tac(filename='/path/to/new_tac.tsv',
+                           tac_data=my_tac_modified)
     """
     try:
         tac_data = np.asarray(np.loadtxt(filename, **kwargs).T, dtype=float, order='C')

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -39,6 +39,33 @@ class TimeActivityCurve:
         return np.ascontiguousarray([self.times, self.activity, self.uncertainty])
 
 
+def safe_load_tac(filename: str, **kwargs) -> np.ndarray:
+    """
+    Loads time-activity curves (TAC) from a file.
+    Tries to read a TAC from specified file and raises an exception if unable to do so. We assume that the file has two
+    columns, the first corresponding to time and second corresponding to activity.
+    Args:
+        filename (str): The name of the file to be loaded.
+    Returns:
+        np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the times, and the second
+        corresponds to the activity.
+    Raises:
+        Exception: An error occurred loading the TAC.
+    """
+    try:
+        tac_data = np.asarray(np.loadtxt(filename, **kwargs).T, dtype=float, order='C')
+    except ValueError:
+        tac_data = np.asarray(np.loadtxt(filename, skiprows=1, **kwargs).T, dtype=float, order='C')
+    except Exception as e:
+        print(f"Couldn't read file {filename}. Error: {e}")
+        raise e
+
+    if np.max(tac_data[0]) >= 300:
+        tac_data[0] /= 60.0
+
+    return tac_data
+
+
 class TimeActivityCurveFromFile:
     """
     Class to handle data related to time activity curves (TACs).
@@ -288,28 +315,4 @@ class MultiTACAnalysisMixin:
         return seg_labels
 
 
-def safe_load_tac(filename: str, **kwargs) -> np.ndarray:
-    """
-    Loads time-activity curves (TAC) from a file.
-    Tries to read a TAC from specified file and raises an exception if unable to do so. We assume that the file has two
-    columns, the first corresponding to time and second corresponding to activity.
-    Args:
-        filename (str): The name of the file to be loaded.
-    Returns:
-        np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the times, and the second
-        corresponds to the activity.
-    Raises:
-        Exception: An error occurred loading the TAC.
-    """
-    try:
-        tac_data = np.asarray(np.loadtxt(filename, **kwargs).T, dtype=float, order='C')
-    except ValueError:
-        tac_data = np.asarray(np.loadtxt(filename, skiprows=1, **kwargs).T, dtype=float, order='C')
-    except Exception as e:
-        print(f"Couldn't read file {filename}. Error: {e}")
-        raise e
 
-    if np.max(tac_data[0]) >= 300:
-        tac_data[0] /= 60.0
-
-    return tac_data

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -209,7 +209,7 @@ def safe_write_tac(filename: str,
             col_names = ['FrameReferenceTime', 'MeanActivityConcentration']
         elif num_cols==3:
             col_names = ['FrameReferenceTime', 'MeanActivityConcentration','Uncertainty']
-    
+
     if num_cols!=len(col_names):
         raise ValueError("Expected the same number of columns in tac_data and col_names. Got "
                          f"{num_cols} in tac_data and {len(col_names)} in col_names.")

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -63,10 +63,24 @@ class TimeActivityCurve:
 
     @property
     def tac(self) -> np.ndarray:
+        """
+        Get the TAC array, not including uncertainties.
+
+        Returns:
+            (np.ndarray): The TAC as a contiguous array, with the first index being time and the
+                second index being activity.
+        """
         return np.ascontiguousarray([self.times, self.activity])
 
     @property
     def tac_werr(self) -> np.ndarray:
+        """
+        Get the TAC array, including uncertainties.
+
+        Returns:
+            (np.ndarray): The TAC as a contiguous array, with the first index being time and the
+                second index being activity, and the third index being uncertainty.
+        """
         return np.ascontiguousarray([self.times, self.activity, self.uncertainty])
 
     @property

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -7,9 +7,12 @@ TODO:
     * Refactor safe_load_tac to this module as a public method
 
 """
+import os
+import glob
+import pathlib
 from dataclasses import dataclass, field
 import numpy as np
-import os, glob, pathlib
+
 
 @dataclass
 class TimeActivityCurve:

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -89,15 +89,18 @@ def safe_load_tac(filename: str,
                   **kwargs) -> np.ndarray:
     """
     Loads time-activity curves (TAC) from a file.
-    Tries to read a TAC from specified file and raises an exception if unable to do so. We assume that the file has two
-    columns, the first corresponding to time and second corresponding to activity.
+    Tries to read a TAC from specified file and raises an exception if unable to do so. We assume
+    that the file has two columns, the first corresponding to time and second corresponding to
+    activity.
     Args:
-        with_uncertainty (bool):
         filename (str): The name of the file to be loaded.
+        with_uncertainty (bool): Load uncertainty of measured activity along with timing and 
+            activity.
         **kwargs (dict): keyword arguments to pass to :func:`np.loadtxt`.
     Returns:
-        np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the times, and the second
-            corresponds to the activity. If with_uncertainty is True, the third index corresponds to the uncertainty.
+        np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the
+            times, and the second corresponds to the activity. If with_uncertainty is True, the
+            third index corresponds to the uncertainty.
     Raises:
         Exception: An error occurred loading the TAC.
 

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -72,11 +72,10 @@ class TimeActivityCurve:
 
 
     def to_tsv(self, filename: str, col_names: list[str]=None):
-        if self.uncertainty is not None:
-            safe_write_tac(filename=filename,tac_data=self.tac_werr,col_names=col_names)
-        else:
+        if np.any(self.uncertainty==0):
             safe_write_tac(filename=filename,tac_data=self.tac,col_names=col_names)
-
+        else:
+            safe_write_tac(filename=filename,tac_data=self.tac_werr,col_names=col_names)
 
 
 def safe_load_tac(filename: str,

--- a/petpal/utils/time_activity_curve.py
+++ b/petpal/utils/time_activity_curve.py
@@ -9,7 +9,6 @@ TODO:
 """
 from dataclasses import dataclass
 import numpy as np
-from .image_io import safe_load_tac
 import os, glob, pathlib
 
 @dataclass
@@ -270,3 +269,30 @@ class MultiTACAnalysisMixin:
             seg_labels.append(tmp_seg)
             
         return seg_labels
+
+
+def safe_load_tac(filename: str, **kwargs) -> np.ndarray:
+    """
+    Loads time-activity curves (TAC) from a file.
+    Tries to read a TAC from specified file and raises an exception if unable to do so. We assume that the file has two
+    columns, the first corresponding to time and second corresponding to activity.
+    Args:
+        filename (str): The name of the file to be loaded.
+    Returns:
+        np.ndarray: A numpy array containing the loaded TAC. The first index corresponds to the times, and the second
+        corresponds to the activity.
+    Raises:
+        Exception: An error occurred loading the TAC.
+    """
+    try:
+        tac_data = np.asarray(np.loadtxt(filename, **kwargs).T, dtype=float, order='C')
+    except ValueError:
+        tac_data = np.asarray(np.loadtxt(filename, skiprows=1, **kwargs).T, dtype=float, order='C')
+    except Exception as e:
+        print(f"Couldn't read file {filename}. Error: {e}")
+        raise e
+
+    if np.max(tac_data[0]) >= 300:
+        tac_data[0] /= 60.0
+
+    return tac_data

--- a/petpal/visualizations/graphical_plots.py
+++ b/petpal/visualizations/graphical_plots.py
@@ -25,7 +25,7 @@ from typing import Dict, Union, Type
 from matplotlib import pyplot as plt
 import numpy as np
 from ..kinetic_modeling import graphical_analysis as pet_grph
-from ..utils.image_io import safe_load_tac
+from utils.time_activity_curve import safe_load_tac
 
 
 class GraphicalAnalysisPlot(ABC):

--- a/petpal/visualizations/graphical_plots.py
+++ b/petpal/visualizations/graphical_plots.py
@@ -25,7 +25,7 @@ from typing import Dict, Union, Type
 from matplotlib import pyplot as plt
 import numpy as np
 from ..kinetic_modeling import graphical_analysis as pet_grph
-from utils.time_activity_curve import safe_load_tac
+from ..utils.time_activity_curve import safe_load_tac
 
 
 class GraphicalAnalysisPlot(ABC):

--- a/test_notebooks/explicit_tac_fitting/01_fitting_TCMs.ipynb
+++ b/test_notebooks/explicit_tac_fitting/01_fitting_TCMs.ipynb
@@ -36,7 +36,7 @@
     "import petpal.kinetic_modeling.tcms_as_convolutions as pet_tcm\n",
     "import petpal.kinetic_modeling.tac_fitting as pet_fit\n",
     "import petpal.utils.testing_utils as pet_test\n",
-    "from utils.time_activity_curve import safe_load_tac\n",
+    "from petpal.utils.time_activity_curve import safe_load_tac\n",
     "from petpal.utils.testing_utils import TACPlots\n",
     "from importlib import reload\n",
     "\n",

--- a/test_notebooks/explicit_tac_fitting/01_fitting_TCMs.ipynb
+++ b/test_notebooks/explicit_tac_fitting/01_fitting_TCMs.ipynb
@@ -36,7 +36,7 @@
     "import petpal.kinetic_modeling.tcms_as_convolutions as pet_tcm\n",
     "import petpal.kinetic_modeling.tac_fitting as pet_fit\n",
     "import petpal.utils.testing_utils as pet_test\n",
-    "from petpal.utils.image_io import safe_load_tac\n",
+    "from utils.time_activity_curve import safe_load_tac\n",
     "from petpal.utils.testing_utils import TACPlots\n",
     "from importlib import reload\n",
     "\n",

--- a/test_notebooks/testing_RTMs/01_testing_RTMs.ipynb
+++ b/test_notebooks/testing_RTMs/01_testing_RTMs.ipynb
@@ -26,7 +26,7 @@
     "import seaborn as sns\n",
     "import petpal.kinetic_modeling.tcms_as_convolutions as pet_tcm\n",
     "import petpal.kinetic_modeling.reference_tissue_models as pet_rtms\n",
-    "from utils.time_activity_curve import safe_load_tac\n",
+    "from petpal.utils.time_activity_curve import safe_load_tac\n",
     "from petpal.utils.testing_utils import generate_random_parameter_samples, add_gaussian_noise_to_tac_based_on_max, scatter_with_regression_figure, bland_atlman_figure, ratio_bland_atlman_figure\n",
     "from importlib import reload\n",
     "\n",

--- a/test_notebooks/testing_RTMs/01_testing_RTMs.ipynb
+++ b/test_notebooks/testing_RTMs/01_testing_RTMs.ipynb
@@ -26,7 +26,7 @@
     "import seaborn as sns\n",
     "import petpal.kinetic_modeling.tcms_as_convolutions as pet_tcm\n",
     "import petpal.kinetic_modeling.reference_tissue_models as pet_rtms\n",
-    "from petpal.utils.image_io import safe_load_tac\n",
+    "from utils.time_activity_curve import safe_load_tac\n",
     "from petpal.utils.testing_utils import generate_random_parameter_samples, add_gaussian_noise_to_tac_based_on_max, scatter_with_regression_figure, bland_atlman_figure, ratio_bland_atlman_figure\n",
     "from importlib import reload\n",
     "\n",


### PR DESCRIPTION
Adds functionality to the TimeActivityCurve dataclass by allowing the user to read and write TAC objects. Deprecates TimeActivityCurveFromFile as all features are adopted by TimeActivityCurve: any code that used TACFF now uses TAC. Refactors safe_load_tac from image_io to time_activity_curve, and creates new function safe_write_tac to do the reverse operation. 

Also fixes a small bug rounding values that don't exist in MRTM2 parameter saving. Rounding was removed.