### PR TITLE
Feat/rescale image step

### DIFF
--- a/petpal/pipelines/preproc_steps.py
+++ b/petpal/pipelines/preproc_steps.py
@@ -578,18 +578,19 @@ class ImageToImageStep(FunctionBasedStep):
         self.output_image_path = filepath
     
     @classmethod
-    def default_threshold_cropping(cls, **overrides):
+    def default_threshold_cropping(cls, name: str = 'thresh_crop',  **overrides):
         """
         Creates a default instance for threshold cropping using :class:`SimpleAutoImageCropper<petpal.preproc.image_operations_4d.SimpleAutoImageCropper>`.
         All paths are empty-strings.
 
         Args:
+            name (str): Name of the step. Defaults to 'thresh_crop'.
             **overrides: Override default parameters.
 
         Returns:
             ImageToImageStep: A new instance for threshold cropping.
         """
-        defaults = dict(name='thresh_crop', function=SimpleAutoImageCropper, input_image_path='',
+        defaults = dict(name=name, function=SimpleAutoImageCropper, input_image_path='',
                         output_image_path='', )
         override_dict = defaults | overrides
         try:
@@ -599,20 +600,21 @@ class ImageToImageStep(FunctionBasedStep):
             return cls(**defaults)
     
     @classmethod
-    def default_moco_frames_above_mean(cls, verbose=False, **overrides):
+    def default_moco_frames_above_mean(cls, name: str = 'moco_frames_above_mean', verbose=False, **overrides):
         """
         Creates a default instance for motion correction frames above mean value using
         :func:`motion_corr_frames_above_mean_value<petpal.preproc.motion_corr.motion_corr_frames_above_mean_value>`.
         All paths are empty-strings.
 
         Args:
+            name (str): Name of the step. Defaults to 'moco_frames_above_mean'
             verbose (bool): Whether to run in verbose mode.
             **overrides: Override default parameters.
 
         Returns:
             ImageToImageStep: A new instance for motion correction frames above mean value.
         """
-        defaults = dict(name='moco_frames_above_mean', function=motion_corr_frames_above_mean_value,
+        defaults = dict(name=name, function=motion_corr_frames_above_mean_value,
                         input_image_path='', output_image_path='', motion_target_option='mean_image', verbose=verbose,
                         half_life=None, )
         override_dict = defaults | overrides
@@ -623,20 +625,21 @@ class ImageToImageStep(FunctionBasedStep):
             return cls(**defaults)
 
     @classmethod
-    def default_windowed_moco(cls, verbose=False, **overrides):
+    def default_windowed_moco(cls, name: str = 'windowed_moco', verbose=False, **overrides):
         """
         Creates a default instance for motion correction of frames using a windowed strategy.
         See :func:`windowed_motion_corr_to_target<petpal.preproc.motion_corr.windowed_motion_corr_to_target>`
         for more details. All paths are empty-strings.
 
         Args:
+            name (str): Name of the step. Defaults to 'windowed_moco'.
             verbose:
             **overrides:
 
         Returns:
             ImageToImageStep: A new instance for windowed motion correction of frames.
         """
-        defaults = dict(name='windowed_moco', function=windowed_motion_corr_to_target,
+        defaults = dict(name=name, function=windowed_motion_corr_to_target,
                         input_image_path='', output_image_path='',
                         motion_target_option='weighted_series_sum', w_size=60.0,
                         verbose=verbose)
@@ -648,12 +651,13 @@ class ImageToImageStep(FunctionBasedStep):
             return cls(**defaults)
 
     @classmethod
-    def default_register_pet_to_t1(cls, reference_image_path='', half_life:float=None, verbose=False, **overrides):
+    def default_register_pet_to_t1(cls, name:str = 'register_pet_to_t1', reference_image_path='', half_life:float=None, verbose=False, **overrides):
         """
         Creates a default instance for registering PET to T1 image using :func:`register_pet<petpal.preproc.register.register_pet>`.
         All paths are empty-strings.
 
         Args:
+            name (str): Name of the step. Defaults to 'register_pet_to_t1'
             reference_image_path (str): Path to the reference image.
             half_life (float): Half-life value, in seconds, for the radiotracer. Used to
                 generate a weighted_series_sum image.
@@ -664,7 +668,7 @@ class ImageToImageStep(FunctionBasedStep):
             ImageToImageStep: A new instance for registering PET to T1 image.
 
         """
-        defaults = dict(name='register_pet_to_t1', function=register_pet, input_image_path='', output_image_path='',
+        defaults = dict(name=name, function=register_pet, input_image_path='', output_image_path='',
                         reference_image_path=reference_image_path, motion_target_option='weighted_series_sum',
                         verbose=verbose, half_life=half_life)
         override_dict = defaults | overrides
@@ -675,7 +679,7 @@ class ImageToImageStep(FunctionBasedStep):
             return cls(**defaults)
 
     @classmethod
-    def default_rescale_image(cls, **overrides):
+    def default_rescale_image(cls, name: str = 'rescale_image', **overrides):
         r"""Creates a default step-instance for rescaling an image using :class:`rescale_image<petpal.preproc.image_operations_4d.rescale_image>`.
 
         The defaults for this step will divide the input image by 37000.0 which is usually done to go
@@ -687,12 +691,13 @@ class ImageToImageStep(FunctionBasedStep):
              paths.
 
         Args:
+            name (str): Name of the step. Defaults to 'rescale_image'.
             **overrides:
 
         Returns:
             ImageToImageStep: A new step instance for rescaling the input image.
         """
-        defaults = dict(name='rescale_image', function=ANTsImageToANTsImage(rescale_image),
+        defaults = dict(name=name, function=ANTsImageToANTsImage(rescale_image),
                         input_image_path='', output_image_path='',
                         rescale_constant=37000.0, op='/')
         override_dict = defaults | overrides

--- a/petpal/pipelines/preproc_steps.py
+++ b/petpal/pipelines/preproc_steps.py
@@ -525,7 +525,8 @@ class ImageToImageStep(FunctionBasedStep):
         sup_str_list.insert(args_ind, f"Input & Output Paths:\n{io_dict}")
         def_args_ind = sup_str_list.index("Default Arguments:")
         sup_str_list.pop(def_args_ind + 1)
-        sup_str_list.pop(def_args_ind + 1)
+        if not hasattr(self.function, '__wrapped__'):
+            sup_str_list.pop(def_args_ind + 1)
         
         return "\n".join(sup_str_list)
     

--- a/petpal/pipelines/steps_base.py
+++ b/petpal/pipelines/steps_base.py
@@ -118,8 +118,9 @@ class FunctionBasedStep(StepsAPI):
         func_params = self.func_sig.parameters
         arg_names = list(func_params)
         for arg_name in arg_names[len(self.args):]:
-            if arg_name not in self.kwargs and arg_name != 'kwargs':
-                unset_args_dict[arg_name] = func_params[arg_name].default
+            if arg_name not in self.kwargs:
+                if (func_params[arg_name].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD):
+                    unset_args_dict[arg_name] = func_params[arg_name].default
         return unset_args_dict
     
     def get_empty_default_kwargs(self) -> list:
@@ -320,7 +321,8 @@ class ObjectBasedStep(StepsAPI):
         unset_args_dict = ArgsDict()
         for arg_name, arg_val in sig.parameters.items():
             if arg_name not in kwargs and arg_name != 'self':
-                unset_args_dict[arg_name] = arg_val.default
+                if arg_val.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
+                    unset_args_dict[arg_name] = arg_val.default
         return unset_args_dict
     
     def get_empty_default_kwargs(self, sig: inspect.Signature, set_kwargs: dict) -> list:

--- a/petpal/preproc/image_operations_4d.py
+++ b/petpal/preproc/image_operations_4d.py
@@ -176,6 +176,43 @@ def crop_image(input_image_path: str,
 
 
 def rescale_image(input_image: ants.core.ANTsImage, rescale_constant: float, op: str = '/') -> ants.core.ANTsImage:
+    r"""Rescales a 3D or 4D ANTsImage intensity values by performing division or
+    multiplication with a given constant.
+
+    This function supports two operations: dividing the input image by a
+    rescale constant or multiplying it by the constant. Division is only
+    allowed with a positive rescale constant to avoid invalid operations.
+    The operation is applied element-wise across the image data.
+
+    Args:
+        input_image (ants.core.ANTsImage): Input image, given as an ANTsImage object.
+        rescale_constant (float): The constant to rescale the image intensities. For division (`op="/"`),
+            this value must be greater than zero.
+        op (str, optional): Operation to perform, either `'/'` for division or `'*'` for
+            multiplication. Default is `'/'`.
+
+    Returns:
+        ants.core.ANTsImage: The rescaled ANTsImage with updated intensity values.
+
+    Raises:
+        AssertionError: If `op` is not one of `'/'` or `'*'`.
+        AssertionError: If division (`op="/"`) is requested, but `rescale_constant` is not greater than zero.
+
+    Example:
+        .. code-block:: python
+
+            import ants
+            from petpal.preproc.image_operations_4d import rescale_image
+
+            # Load a sample ANTsImage
+            input_img = ants.image_read('example_image.nii')
+
+            # Rescale intensities by division with a constant (e.g., 2.0)
+            rescaled_img = rescale_image(input_image=input_img, rescale_constant=2.0, op='/')
+
+            # Rescale intensities by multiplication with a constant (e.g., 1.5)
+            rescaled_img = rescale_image(input_image=input_img, rescale_constant=1.5, op='*')
+    """
     assert op in ('/', '*'), "Operations supported by this function are `/` (division) or `*` (multiplication)."
     if op == '/':
         assert rescale_constant > 0, "Rescaling constant must be greater than zero."

--- a/petpal/preproc/image_operations_4d.py
+++ b/petpal/preproc/image_operations_4d.py
@@ -175,6 +175,15 @@ def crop_image(input_image_path: str,
     return cropped_image
 
 
+def rescale_image(input_image: ants.core.ANTsImage, rescale_constant: float, op: str = '/') -> ants.core.ANTsImage:
+    assert op in ('/', '*'), "Operations supported by this function are `/` (division) or `*` (multiplication)."
+    if op == '/':
+        assert rescale_constant > 0, "Rescaling constant must be greater than zero."
+        return input_image
+    else:
+        input_image * rescale_constant
+
+
 def determine_motion_target(motion_target_option: str | tuple | list,
                             input_image_4d_path: str = None,
                             half_life: float = None) -> str:

--- a/petpal/preproc/image_operations_4d.py
+++ b/petpal/preproc/image_operations_4d.py
@@ -218,7 +218,7 @@ def rescale_image(input_image: ants.core.ANTsImage, rescale_constant: float, op:
         assert rescale_constant > 0, "Rescaling constant must be greater than zero."
         return input_image / rescale_constant
     else:
-        input_image * rescale_constant
+        return input_image * rescale_constant
 
 
 def determine_motion_target(motion_target_option: str | tuple | list,

--- a/petpal/preproc/image_operations_4d.py
+++ b/petpal/preproc/image_operations_4d.py
@@ -179,7 +179,7 @@ def rescale_image(input_image: ants.core.ANTsImage, rescale_constant: float, op:
     assert op in ('/', '*'), "Operations supported by this function are `/` (division) or `*` (multiplication)."
     if op == '/':
         assert rescale_constant > 0, "Rescaling constant must be greater than zero."
-        return input_image
+        return input_image / rescale_constant
     else:
         input_image * rescale_constant
 


### PR DESCRIPTION
Added a simple function that returns a divided or multiplied ants image, which is then used to write a new default rescale image step in preproc steps.